### PR TITLE
Add in_progress and queued to WorkflowJobStepConclusion enums

### DIFF
--- a/.github/workflows/add_to_octokit_project.yml
+++ b/.github/workflows/add_to_octokit_project.yml
@@ -5,7 +5,7 @@ on:
     types: [reopened, opened]
   pull_request:
     types: [reopened, opened]
-    
+
 jobs:
   add-to-project:
     name: Add issue to project
@@ -15,5 +15,5 @@ jobs:
         with:
           project-url: https://github.com/orgs/octokit/projects/10
           github-token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
-          labeled: 'Status: Stale'
+          labeled: "Status: Stale"
           label-operator: NOT

--- a/.github/workflows/add_to_octokit_project.yml
+++ b/.github/workflows/add_to_octokit_project.yml
@@ -1,0 +1,19 @@
+name: Add PRs and issues to Octokit org project
+
+on:
+  issues:
+    types: [reopened, opened]
+  pull_request:
+    types: [reopened, opened]
+    
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/octokit/projects/10
+          github-token: ${{ secrets.OCTOKITBOT_PROJECT_ACTION_TOKEN }}
+          labeled: 'Status: Stale'
+          label-operator: NOT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           lfs: true
           fetch-depth: 0

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,12 +21,12 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@678fc3afe258fb2e0cdc165ccf77b85719de7b3c # v2.1.33
+        uses: github/codeql-action/init@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
         with:
           languages: 'csharp'
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@678fc3afe258fb2e0cdc165ccf77b85719de7b3c # v2.1.33
+        uses: github/codeql-action/autobuild@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@678fc3afe258fb2e0cdc165ccf77b85719de7b3c # v2.1.33
+        uses: github/codeql-action/analyze@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,12 +21,12 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b2a92eb56d8cb930006a1c6ed86b0782dd8a4297 # v2.1.35
+        uses: github/codeql-action/init@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36
         with:
           languages: 'csharp'
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@b2a92eb56d8cb930006a1c6ed86b0782dd8a4297 # v2.1.35
+        uses: github/codeql-action/autobuild@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b2a92eb56d8cb930006a1c6ed86b0782dd8a4297 # v2.1.35
+        uses: github/codeql-action/analyze@a669cc5936cc5e1b6a362ec1ff9e410dc570d190 # v2.1.36

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,12 +21,12 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
+        uses: github/codeql-action/init@b2a92eb56d8cb930006a1c6ed86b0782dd8a4297 # v2.1.35
         with:
           languages: 'csharp'
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
+        uses: github/codeql-action/autobuild@b2a92eb56d8cb930006a1c6ed86b0782dd8a4297 # v2.1.35
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@312e093a1892bd801f026f1090904ee8e460b9b6 # v2.1.34
+        uses: github/codeql-action/analyze@b2a92eb56d8cb930006a1c6ed86b0782dd8a4297 # v2.1.35

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,29 @@
+name: 'Close stale issues and PRs'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v6
+        with:
+          stale-issue-message: >
+            👋 Hey Friends, this issue has been automatically marked as `stale` because it has no recent activity.
+            It will be closed if no further activity occurs.
+            Please add the `Status: Pinned` label if you feel that this issue needs to remain open/active.
+            Thank you for your contributions and help in keeping things tidy!
+          stale-pr-message: >
+            👋 Hey Friends, this pull request has been automatically marked as `stale` because it has no recent activity.
+            It will be closed if no further activity occurs.
+            Please add the `Status: Pinned` label if you feel that this issue needs to remain open/active.
+            Thank you for your contributions and help in keeping things tidy!
+          days-before-stale: 270
+          days-before-close: 7
+          exempt-issue-labels: 'Status: Pinned'
+          exempt-pr-labels: 'Status: Pinned'
+          operations-per-run: 100
+          stale-issue-label: 'Status: Stale'
+          stale-pr-label: 'Status: Stale'

--- a/src/Octokit.Webhooks/Events/WorkflowRun/WorkflowRunAction.cs
+++ b/src/Octokit.Webhooks/Events/WorkflowRun/WorkflowRunAction.cs
@@ -5,6 +5,8 @@ public sealed record WorkflowRunAction : WebhookEventAction
 {
     public static readonly WorkflowRunAction Completed = new(WorkflowRunActionValue.Completed);
 
+    public static readonly WorkflowRunAction InProgress = new(WorkflowRunActionValue.InProgress);
+
     public static readonly WorkflowRunAction Requested = new(WorkflowRunActionValue.Requested);
 
     private WorkflowRunAction(string value)

--- a/src/Octokit.Webhooks/Events/WorkflowRun/WorkflowRunActionValue.cs
+++ b/src/Octokit.Webhooks/Events/WorkflowRun/WorkflowRunActionValue.cs
@@ -4,5 +4,7 @@ public static class WorkflowRunActionValue
 {
     public const string Completed = "completed";
 
+    public const string InProgress = "in_progress";
+
     public const string Requested = "requested";
 }

--- a/src/Octokit.Webhooks/Events/WorkflowRun/WorkflowRunInProgressEvent.cs
+++ b/src/Octokit.Webhooks/Events/WorkflowRun/WorkflowRunInProgressEvent.cs
@@ -1,0 +1,9 @@
+namespace Octokit.Webhooks.Events.WorkflowRun;
+
+[PublicAPI]
+[WebhookActionType(WorkflowRunActionValue.InProgress)]
+public sealed record WorkflowRunInProgressEvent : WorkflowRunEvent
+{
+    [JsonPropertyName("action")]
+    public override string Action => WorkflowRunAction.InProgress;
+}

--- a/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepConclusion.cs
+++ b/src/Octokit.Webhooks/Models/WorkflowJobEvent/WorkflowJobStepConclusion.cs
@@ -11,4 +11,8 @@ public enum WorkflowJobStepConclusion
     Skipped,
     [EnumMember(Value = "success")]
     Success,
+    [EnumMember(Value = "in_progress")]
+    InProgress,
+    [EnumMember(Value = "queued")]
+    Queued,
 }

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -9,7 +9,7 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.8.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0"/>
-    <PackageReference Include="Moq" Version="4.18.2"/>
+    <PackageReference Include="Moq" Version="4.18.3"/>
     <PackageReference Include="xunit" Version="2.4.2"/>
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="all" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #169

----

## Behavior

### Before the change?
When a workflow_job.completed with a `failed` conclusion event is deserialized it fails because steps can be have `in_progress` and `queued` status which are not included in the WorkflowJobStepConclusion enums

* 

### After the change?
The `in_progress` & `queued`  status steps can be deserialized for a workflowflow completed event

* 


### Other information
<!-- Any other information that is important to this PR  -->

* 

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

